### PR TITLE
Implement 

### DIFF
--- a/src/assets/styles/themes/_default.scss
+++ b/src/assets/styles/themes/_default.scss
@@ -24,6 +24,7 @@
   --color-primary: rgba(61, 121, 185, 1);
   --color-primary-hover: rgba(50, 82, 119, 1);
   --input-border: rgba(221, 223, 231, 1);
+  --input-focus: rgb(64, 158, 255);
   --loading: var(--color-primary);
   --modal-bg: rgba(255, 255, 255, 1);
   --modal-title: rgba(107, 107, 107, 1);

--- a/src/assets/styles/themes/_element.scss
+++ b/src/assets/styles/themes/_element.scss
@@ -36,14 +36,16 @@ $--font-path: '~element-ui/lib/theme-chalk/fonts';
     content: '';
   }
 }
+
 .el-form-item__error {
   position: relative;
 }
 
 /* Overrides el-input */
-.error .el-input__inner {
-  border: 1px solid var(--color-error);
-}
 .el-input__inner {
   @extend %body-1;
+}
+
+.error .el-input__inner {
+  border: 1px solid var(--color-error);
 }

--- a/src/assets/styles/themes/_element.scss
+++ b/src/assets/styles/themes/_element.scss
@@ -36,11 +36,14 @@ $--font-path: '~element-ui/lib/theme-chalk/fonts';
     content: '';
   }
 }
-
 .el-form-item__error {
   position: relative;
 }
 
+/* Overrides el-input */
+.error .el-input__inner {
+  border: 1px solid var(--color-error);
+}
 .el-input__inner {
   @extend %body-1;
 }

--- a/src/components/accounts/AccountToolbar.vue
+++ b/src/components/accounts/AccountToolbar.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="account-toolbar">
+    <sad-button
+      icon="file-invoice-dollar"
+      type="ghost"
+      size="small"
+      data-test="new-transaction"
+      @click="toggle('transactionDrawer')"
+    >
+      {{ t('newTransaction') }}
+    </sad-button>
+
+    <transaction-details
+      v-if="isVisible.transactionDrawer"
+      :origin-account="account"
+      data-test="transaction-drawer"
+      @close="toggle('transactionDrawer')"
+    />
+  </div>
+</template>
+
+<script>
+import SadButton from '@/components/sad/SadButton'
+import TransactionDetails from '@/components/transactions/TransactionDetails'
+import { useI18n } from '@/use/i18n'
+import { defineComponent, reactive } from '@vue/composition-api'
+
+export default defineComponent({
+  props: {
+    account: {
+      type: Object,
+      required: true,
+    },
+  },
+
+  components: {
+    SadButton,
+    TransactionDetails,
+  },
+
+  setup () {
+    const { t } = useI18n()
+    const isVisible = reactive({
+      transactionDrawer: false,
+    })
+    const toggle = (prop) => {
+      isVisible[prop] = !isVisible[prop]
+    }
+
+    return { isVisible, t, toggle }
+  },
+})
+</script>
+
+<style lang="scss" scoped>
+.account-toolbar {
+  border-bottom: 1px solid var(--acc-toolbar-border);
+  display: flex;
+  justify-content: space-between;
+  padding: $base*2 $base*4;
+}
+</style>

--- a/src/components/sad/SadCheckbox.vue
+++ b/src/components/sad/SadCheckbox.vue
@@ -1,0 +1,154 @@
+<template>
+  <div
+    class="sad-checkbox"
+    data-test="sad-checkbox"
+  >
+    <div class="sad-checkbox__input-wrapper">
+      <input
+        :id="id"
+        class="sad-checkbox__input"
+        type="checkbox"
+        :checked="value"
+        :name="name"
+        data-test="input"
+        @input="e => $emit('input', e.target.checked)"
+      >
+      <label
+        class="sad-checkbox__label"
+        :for="id"
+        data-test="label"
+      >
+        {{ label }}
+      </label>
+    </div>
+    <sad-tip
+      v-if="tipText"
+      class="sad-checkbox__tip"
+      :variant="tipVariant"
+      :text="tipText"
+      data-test="tip"
+    />
+  </div>
+</template>
+<script>
+import SadTip from './SadTip'
+import useTip from '@/use/tip'
+import uuid from 'uuid-random'
+
+export default {
+  name: 'SadCheckbox',
+
+  components: {
+    SadTip,
+  },
+
+  props: {
+    name: {
+      type: String,
+      required: true,
+    },
+    label: {
+      type: String,
+      required: true,
+    },
+    id: {
+      type: [String, Number],
+      default: () => uuid(),
+    },
+    value: {
+      type: Boolean,
+      default: false,
+    },
+    tip: {
+      type: String,
+      default: '',
+    },
+  },
+
+  setup (props) {
+    const { tipText, tipVariant } = useTip(props)
+
+    return { tipText, tipVariant }
+  },
+}
+</script>
+
+<style lang="scss">
+.sad-checkbox {
+  $self: &;
+
+  position: relative;
+
+  &__input-wrapper {
+    align-items: center;
+    color: inherit;
+    display: inline-flex;
+    min-height: inherit;
+    position: relative;
+  }
+
+  &__input {
+    opacity: 0;
+    position: absolute;
+
+    + label::after {
+      content: none;
+    }
+
+    &:checked + label::after {
+      content: "";
+    }
+
+    &:focus + label::before,
+    &:active + label::before {
+      border-color: var(--input-focus);
+      transition: 0.2s;
+    }
+
+    &:checked + label::before {
+      background: var(--color-primary);
+      border-color: var(--color-primary);
+    }
+  }
+
+  &__label {
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    height: 6*$base;
+    justify-content: center;
+    padding-left: 6*$base;
+
+    &::before,
+    &::after {
+      content: "";
+      display: inline-block;
+      position: absolute;
+    }
+
+    &::before {
+      background: var(--app-white);
+      border: 2px solid var(--input-border);
+      border-radius: 2px;
+      height: 12px;
+      left: 0;
+      top: 4px;
+      width: 12px;
+    }
+
+    &::after {
+      border-bottom: 2px solid var(--app-white);
+      border-left: 2px solid var(--app-white);
+      height: 4px;
+      left: 3px;
+      top: 8px;
+      transform: rotate(-45deg);
+      width: 8px;
+    }
+  }
+
+  &__tip {
+    margin-top: $base;
+  }
+}
+</style>

--- a/src/components/sad/SadDatePicker.vue
+++ b/src/components/sad/SadDatePicker.vue
@@ -87,6 +87,7 @@ export default defineComponent({
   &__input {
     width: 100%;
   }
+
   &__tip {
     margin-top: $base;
   }

--- a/src/components/sad/SadDatePicker.vue
+++ b/src/components/sad/SadDatePicker.vue
@@ -1,0 +1,94 @@
+<template>
+  <div
+    class="sad-date-picker"
+  >
+    <sad-label
+      to="name"
+      :text="label"
+      data-test="label"
+    >
+      <el-date-picker
+        class="sad-date-picker__input"
+        :class="[errorClass]"
+        type="date"
+        :placeholder="placeholder"
+        :format="format"
+        :value="value"
+        :name="name"
+        value-format="yyyy-MM-dd"
+        data-test="picker"
+        @input="val => $emit('input', val)"
+        @blur="$emit('blur')"
+      />
+    </sad-label>
+    <sad-tip
+      v-if="tipText"
+      class="sad-date-picker__tip"
+      :variant="tipVariant"
+      :text="tipText"
+      data-test="tip"
+    />
+  </div>
+</template>
+
+<script>
+import SadLabel from './SadLabel'
+import SadTip from './SadTip'
+import useTip from '@/use/tip'
+import { defineComponent } from '@vue/composition-api'
+
+export default defineComponent({
+  props: {
+    error: {
+      type: String,
+      default: '',
+    },
+    format: {
+      type: String,
+      required: true,
+    },
+    label: {
+      type: String,
+      required: true,
+    },
+    name: {
+      type: String,
+      required: true,
+    },
+    placeholder: {
+      type: String,
+      default: '',
+    },
+    tip: {
+      type: String,
+      default: '',
+    },
+    value: {
+      type: [String, Date],
+      default: () => new Date(),
+    },
+  },
+
+  components: {
+    SadLabel,
+    SadTip,
+  },
+
+  setup (props) {
+    const { errorClass, tipText, tipVariant } = useTip(props)
+
+    return { errorClass, tipText, tipVariant }
+  },
+})
+</script>
+
+<style lang="scss" scoped>
+.sad-date-picker {
+  &__input {
+    width: 100%;
+  }
+  &__tip {
+    margin-top: $base;
+  }
+}
+</style>

--- a/src/components/sad/SadInput.vue
+++ b/src/components/sad/SadInput.vue
@@ -4,7 +4,8 @@
     <input
       :id="name"
       v-model="val"
-      :class="classes"
+      class="sad-input"
+      :class="[errorClass]"
       data-test="input"
       :placeholder="placeholder"
       :type="type"
@@ -27,7 +28,6 @@ import SadLabel from './SadLabel'
 import SadTip from './SadTip'
 import useTip from '@/use/tip'
 import { VMoney } from 'v-money'
-import { computed } from '@vue/composition-api'
 
 export default {
   props: {
@@ -72,15 +72,9 @@ export default {
   },
 
   setup (props) {
-    const { tipText, tipVariant } = useTip(props)
-    const classes = computed(() => {
-      return {
-        'sad-input': true,
-        'sad-input--error': props.error,
-      }
-    })
+    const { errorClass, tipText, tipVariant } = useTip(props)
 
-    return { classes, tipText, tipVariant }
+    return { errorClass, tipText, tipVariant }
   },
 
   components: {
@@ -140,11 +134,17 @@ export default {
 
   @extend %body-1;
 
+  &:focus,
+  &:active {
+    border-color: var(--input-focus);
+    transition: 0.2s;
+  }
+
   &__tip {
     margin-top: $base;
   }
 
-  &--error {
+  &.error {
     border: 1px solid var(--color-error);
   }
 }

--- a/src/components/sad/SadSelect.vue
+++ b/src/components/sad/SadSelect.vue
@@ -7,25 +7,42 @@
     >
       <el-select
         class="sad-select"
+        :class="[errorClass]"
         :value="value"
         :placeholder="placeholder"
         :disabled="disabled"
+        :allow-create="allowCreate"
+        default-first-option
+        filterable
         data-test="select"
         @input="val => $emit('input', val)"
+        @blur="$emit('blur')"
       >
-        <el-option-group
-          v-for="group in options"
-          :key="group.label"
-          :label="group.label"
-        >
+        <div v-if="grouped">
+          <el-option-group
+            v-for="group in options"
+            :key="group.label"
+            :label="group.label"
+            data-test="select-group"
+          >
+            <el-option
+              v-for="option in group.options"
+              :key="option.value"
+              :label="option.label"
+              :value="option.value"
+              data-test="select-option"
+            />
+          </el-option-group>
+        </div>
+        <div v-else>
           <el-option
-            v-for="option in group.options"
+            v-for="option in options"
             :key="option.value"
             :label="option.label"
             :value="option.value"
             data-test="select-option"
           />
-        </el-option-group>
+        </div>
       </el-select>
     </sad-label>
     <sad-tip
@@ -46,6 +63,10 @@ import { defineComponent } from '@vue/composition-api'
 
 export default defineComponent({
   props: {
+    allowCreate: {
+      type: Boolean,
+      default: false,
+    },
     disabled: {
       type: Boolean,
       default: false,
@@ -53,6 +74,10 @@ export default defineComponent({
     error: {
       type: String,
       default: '',
+    },
+    grouped: {
+      type: Boolean,
+      default: false,
     },
     label: {
       type: String,
@@ -86,8 +111,9 @@ export default defineComponent({
   },
 
   setup (props) {
-    const { tipText, tipVariant } = useTip(props)
-    return { tipText, tipVariant }
+    const { errorClass, tipText, tipVariant } = useTip(props)
+
+    return { errorClass, tipText, tipVariant }
   },
 })
 </script>

--- a/src/components/transactions/TransactionDetails.vue
+++ b/src/components/transactions/TransactionDetails.vue
@@ -1,0 +1,182 @@
+<template>
+  <sad-drawer
+    class="transaction-details"
+    :title="t('newTransaction')"
+    data-test="drawer"
+    @close="$emit('close')"
+  >
+    <sad-select
+      v-model="form.payeeName"
+      class="transaction-details__control"
+      :error="errorMessage($v.form.payeeName)"
+      :label="st('payee')"
+      :options="payeeOptions"
+      :placeholder="t('placeholders.select')"
+      name="payee"
+      allow-create
+      data-test="payee"
+      @blur="validate($v.form.payeeName)"
+    />
+    <sad-select
+      v-model="form.categoryId"
+      class="transaction-details__control"
+      name="category"
+      :error="errorMessage($v.form.categoryId)"
+      :label="st('category')"
+      :options="categoryOptions"
+      :placeholder="t('placeholders.select')"
+      grouped
+      data-test="category"
+      @blur="validate($v.form.categoryId)"
+    />
+    <sad-date-picker
+      v-model="form.referenceAt"
+      class="transaction-details__control"
+      :error="errorMessage($v.form.referenceAt)"
+      :label="st('referenceAt')"
+      :placeholder="st('referenceAt')"
+      :format="openBudget.dateFormat"
+      name="reference-at"
+      data-test="reference-at"
+      @blur="validate($v.form.referenceAt)"
+      @input="validate($v.form.referenceAt)"
+    />
+    <sad-input
+      v-model="form.amount"
+      class="transaction-details__control"
+      :error="errorMessage($v.form.amount)"
+      :label="st('amount')"
+      :money="money"
+      name="amount"
+      data-test="amount"
+      @input="validate($v.form.amount)"
+      @blur="validate($v.form.amount)"
+    />
+    <sad-input
+      v-model="form.memo"
+      class="transaction-details__control"
+      :label="st('memo')"
+      :tip="st('memoTip')"
+      name="memo"
+      data-test="memo"
+    />
+    <sad-checkbox
+      v-model="form.clearedAt"
+      class="transaction-details__control"
+      :label="st('clearedAt')"
+      :tip="st('clearedAtTip')"
+      name="cleared-at"
+      data-test="cleared-at"
+    />
+    <div slot="footer">
+      <sad-button
+        size="normal"
+        type="primary"
+        full-width
+        data-test="save-btn"
+      >
+        {{ t('save') }}
+      </sad-button>
+    </div>
+  </sad-drawer>
+</template>
+
+<script>
+import SadButton from '@/components/sad/SadButton'
+import SadDatePicker from '@/components/sad/SadDatePicker'
+import SadDrawer from '@/components/sad/SadDrawer'
+import SadInput from '@/components/sad/SadInput'
+import SadCheckbox from '@/components/sad/SadCheckbox'
+import SadSelect from '@/components/sad/SadSelect'
+import { currencySettings } from '@/support/money'
+import { categoriesGroupedByGroupId } from '@/repositories/categories'
+import { categoryGroupById } from '@/repositories/category-groups'
+import { openBudget } from '@/repositories/budgets'
+import { payees } from '@/repositories/payees'
+import { required } from 'vuelidate/lib/validators'
+import { useI18n } from '@/use/i18n'
+import { useValidation } from '@/use/validation'
+import { computed, defineComponent, reactive } from '@vue/composition-api'
+
+export default defineComponent({
+  name: 'TransactionDetails',
+
+  props: {
+    originAccount: {
+      type: Object,
+      required: true,
+    },
+  },
+
+  components: {
+    SadButton,
+    SadDatePicker,
+    SadDrawer,
+    SadInput,
+    SadCheckbox,
+    SadSelect,
+  },
+
+  setup ({ originAccount }) {
+    const { t, st } = useI18n('TransactionDetails')
+    const { errorMessage, validate } = useValidation()
+
+    const money = currencySettings(openBudget.value)
+
+    const payeeOptions = computed(() => payees.value.map(p => ({
+      label: p.name,
+      value: p.name,
+    })))
+    const categoryOptions = computed(
+      () => Object
+        .entries(categoriesGroupedByGroupId.value)
+        .map(([groupId, categories]) => ({
+          label: categoryGroupById(groupId).name,
+          options: categories.map(category => ({
+            label: category.name,
+            value: category.id,
+          })),
+        })),
+    )
+
+    const form = reactive({
+      amount: '',
+      clearedAt: false,
+      memo: '',
+      categoryId: '',
+      originId: originAccount.id,
+      payeeName: '',
+      referenceAt: new Date(),
+    })
+
+    return {
+      categoryOptions,
+      errorMessage,
+      form,
+      money,
+      openBudget,
+      payeeOptions,
+      st,
+      t,
+      validate,
+    }
+  },
+
+  validations: {
+    form: {
+      amount: { required },
+      categoryId: { required },
+      payeeName: { required },
+      referenceAt: { required },
+    },
+  },
+})
+</script>
+
+<style lang="scss" scoped>
+.transaction-details {
+  &__control + &__control {
+    margin-top: $base*4;
+  }
+}
+</style>

--- a/src/lang/pt-BR.json
+++ b/src/lang/pt-BR.json
@@ -32,6 +32,7 @@
   "newCategory": "Nova categoria",
   "newCategoryGroup": "Novo grupo",
   "newMonthlyBudget": "Criar orçamento",
+  "newTransaction": "Adicionar transação",
   "CreateAccountModal": {
     "accountType": "De que tipo é essa conta?",
     "created": "Conta criada",

--- a/src/lang/pt-BR.json
+++ b/src/lang/pt-BR.json
@@ -61,9 +61,22 @@
     "password": "Sua senha",
     "signIn": "Entrar"
   },
+  "placeholders": {
+    "select": "Escolha"
+  },
   "save": "Salvar",
   "startingBalance": "Saldo inicial",
   "toBeBudgeted": "Disponível",
+  "TransactionDetails": {
+    "amount":"Valor",
+    "category":"Categoria",
+    "clearedAt":"Aprovada?",
+    "clearedAtTip":"Uma transação está aprovada quando está refletida no seu saldo.",
+    "memo":"Descrição",
+    "memoTip":"Opcional. Algo que te ajude a reconhecer essa transação.",
+    "payee":"Recebedor",
+    "referenceAt": "Data"
+  },
   "validations": {
     "required": "Campo obrigatório."
   }

--- a/src/repositories/categories.js
+++ b/src/repositories/categories.js
@@ -1,11 +1,16 @@
 import { get, post } from '@/api'
-import { ref } from '@vue/composition-api'
+import { computed, ref } from '@vue/composition-api'
+import groupBy from 'lodash/groupBy'
 
 export const categories = ref([])
 
 export const categoriesByGroupId = (groupId) => {
   return categories.value.filter(c => c.categoryGroupId === groupId)
 }
+
+export const categoriesGroupedByGroupId = computed(
+  () => groupBy(categories.value, c => c.categoryGroupId),
+)
 
 export const categoryById = (id) => {
   return categories.value.find(c => c.id === id)

--- a/src/repositories/payees.js
+++ b/src/repositories/payees.js
@@ -1,0 +1,12 @@
+import { get } from '@/api'
+import { ref } from '@vue/composition-api'
+
+export const payees = ref([])
+
+export const getPayees = async (params) => {
+  const response = await get(
+    `budgets/${params.budgetId}/payees`,
+  )
+
+  payees.value = response
+}

--- a/src/use/tip.js
+++ b/src/use/tip.js
@@ -3,8 +3,10 @@ import { computed } from '@vue/composition-api'
 export default function useTip (props) {
   const tipText = computed(() => props.error || props.tip)
   const tipVariant = computed(() => props.error ? 'error' : 'info')
+  const errorClass = computed(() => props.error ? 'error' : '')
 
   return {
+    errorClass,
     tipText,
     tipVariant,
   }

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -23,8 +23,11 @@ import Loading from '@/components/Loading'
 import { getAccounts } from '@/repositories/accounts'
 import { getCategoryGroups } from '@/repositories/category-groups'
 import { getCategories } from '@/repositories/categories'
+import { getMonthlyBudgets } from '@/repositories/monthly-budgets'
+import { getPayees } from '@/repositories/payees'
 import { getBudgetById, openBudget } from '@/repositories/budgets'
 import { getMe } from '@/repositories/auth'
+import { isoMonth } from '@/support/date'
 import { ref } from '@vue/composition-api'
 
 const MD_BREAKPOINT = 768
@@ -57,10 +60,15 @@ export default {
     await this.validateSession()
     await getBudgetById(this.$route.params.budgetId)
 
+    const params = { budgetId: openBudget.value.id }
+
     await Promise.all([
-      getAccounts({ budgetId: openBudget.value.id }),
-      getCategoryGroups({ budgetId: openBudget.value.id }),
-      getCategories({ budgetId: openBudget.value.id }),
+      getAccounts(params),
+      getCategoryGroups(params),
+      getCategories(params),
+      getPayees(params),
+      // FIXME: account screens rely on that, maybe move it to a more specific view
+      getMonthlyBudgets({ ...params, isoMonth: isoMonth(new Date()) }),
     ])
     this.loading = false
   },

--- a/src/views/dashboard/AccountShow.vue
+++ b/src/views/dashboard/AccountShow.vue
@@ -5,14 +5,19 @@
       class="account-show__loading"
       data-test="loading"
     />
-    <account-header
-      v-else
-      :name="account.name"
-      :cleared="account.clearedBalance"
-      :uncleared="account.unclearedBalance"
-      :budget="openBudget"
-      data-test="header"
-    />
+    <div v-else>
+      <account-header
+        :name="account.name"
+        :cleared="account.clearedBalance"
+        :uncleared="account.unclearedBalance"
+        :budget="openBudget"
+        data-test="header"
+      />
+      <account-toolbar
+        :account="account"
+        data-test="toolbar"
+      />
+    </div>
   </div>
 </template>
 
@@ -20,6 +25,7 @@
 import { openBudget } from '@/repositories/budgets'
 import { accounts, getAccountById } from '@/repositories/accounts'
 import AccountHeader from '@/components/accounts/AccountHeader'
+import AccountToolbar from '@/components/accounts/AccountToolbar'
 import Loading from '@/components/Loading'
 
 export default {
@@ -27,6 +33,7 @@ export default {
 
   components: {
     AccountHeader,
+    AccountToolbar,
     Loading,
   },
 

--- a/tests/unit/factories/category-group.js
+++ b/tests/unit/factories/category-group.js
@@ -3,8 +3,8 @@ import { Factory } from 'fishery'
 
 export default Factory.define(() => {
   return {
-    budgetId: Faker.random.uuid(),
-    id: Faker.random.uuid(),
+    budgetId: Faker.datatype.uuid(),
+    id: Faker.datatype.uuid(),
     name: Faker.commerce.productMaterial(),
   }
 })

--- a/tests/unit/factories/category.js
+++ b/tests/unit/factories/category.js
@@ -3,8 +3,8 @@ import { Factory } from 'fishery'
 
 export default Factory.define(() => {
   return {
-    categoryGroupId: Faker.random.uuid(),
-    id: Faker.random.uuid(),
+    categoryGroupId: Faker.datatype.uuid(),
+    id: Faker.datatype.uuid(),
     name: Faker.commerce.product(),
   }
 })

--- a/tests/unit/factories/current-user.js
+++ b/tests/unit/factories/current-user.js
@@ -4,7 +4,7 @@ import { Factory } from 'fishery'
 export default Factory.define(() => {
   return {
     email: faker.internet.email(),
-    id: faker.random.uuid(),
+    id: faker.datatype.uuid(),
     name: faker.name.findName(),
   }
 })

--- a/tests/unit/factories/index.js
+++ b/tests/unit/factories/index.js
@@ -6,6 +6,7 @@ import currentUser from './current-user'
 import money from './money'
 import month from './month'
 import monthlyBudget from './monthly-budget'
+import payee from './payee'
 
 export default {
   account,
@@ -16,4 +17,5 @@ export default {
   money,
   month,
   monthlyBudget,
+  payee,
 }

--- a/tests/unit/factories/money.js
+++ b/tests/unit/factories/money.js
@@ -5,8 +5,8 @@ import { Factory } from 'fishery'
 
 export default Factory.define(({ params }) => {
   const currency = params.currency || sample(currencies)
-  const units = params.units || faker.random.number(5000)
-  const cents = params.cents || faker.random.number(99)
+  const units = params.units || faker.datatype.number(5000)
+  const cents = params.cents || faker.datatype.number(99)
 
   return `${currency} ${units},${cents}`
 })

--- a/tests/unit/factories/month.js
+++ b/tests/unit/factories/month.js
@@ -4,7 +4,7 @@ import { Factory } from 'fishery'
 
 const randomMonth = () => {
   const years = [2019, 2020, 2021]
-  const month = Faker.random.number({ min: 1, max: 12 })
+  const month = Faker.datatype.number({ min: 1, max: 12 })
   const formattedMonth = (month < 10) ? `0${month}` : month
 
   return `${sample(years)}-${formattedMonth}`
@@ -12,10 +12,10 @@ const randomMonth = () => {
 
 export default Factory.define(() => {
   return {
-    id: Faker.random.uuid(),
-    activity: Faker.random.number(6500),
-    income: Faker.random.number(5000),
+    id: Faker.datatype.uuid(),
+    activity: Faker.datatype.number(6500),
+    income: Faker.datatype.number(5000),
     isoMonth: randomMonth(),
-    toBeBudgeted: Faker.random.number(6000),
+    toBeBudgeted: Faker.datatype.number(6000),
   }
 })

--- a/tests/unit/factories/monthly-budget.js
+++ b/tests/unit/factories/monthly-budget.js
@@ -1,7 +1,7 @@
 import faker from 'faker'
 import { Factory } from 'fishery'
 
-const randInt = (min, max) => faker.random.number({ min, max })
+const randInt = (min, max) => faker.datatype.number({ min, max })
 
 class MonthlyBudgetFactory extends Factory {
   negative () {
@@ -33,11 +33,11 @@ export default MonthlyBudgetFactory.define(({ params }) => {
   const activity = params.activity || randInt(20000, 80000)
 
   return {
-    id: faker.random.uuid(),
+    id: faker.datatype.uuid(),
     activity,
     budgeted,
     available: budgeted - activity,
-    categoryId: faker.random.uuid(),
-    categoryGroupId: faker.random.uuid(),
+    categoryId: faker.datatype.uuid(),
+    categoryGroupId: faker.datatype.uuid(),
   }
 })

--- a/tests/unit/factories/payee.js
+++ b/tests/unit/factories/payee.js
@@ -1,0 +1,10 @@
+import Faker from 'faker'
+import { Factory } from 'fishery'
+
+export default Factory.define(() => {
+  return {
+    budgetId: Faker.datatype.uuid(),
+    id: Faker.datatype.uuid(),
+    name: Faker.commerce.product(),
+  }
+})

--- a/tests/unit/specs/components/accounts/AccountToolbar.spec.js
+++ b/tests/unit/specs/components/accounts/AccountToolbar.spec.js
@@ -1,0 +1,38 @@
+import AccountToolbar from '@/components/accounts/AccountToolbar'
+import factories from '#/factories'
+import { factoryBuilder } from '#/factory-builder'
+
+const account = factories.account.build()
+
+const factory = () => factoryBuilder(AccountToolbar, {
+  propsData: {
+    account,
+  },
+})
+
+describe('AccountToolbar', () => {
+  it('renders new group button', () => {
+    const wrapper = factory()
+    const item = wrapper.find("[data-test='new-transaction']")
+
+    expect(item.text()).toMatch('newTransaction')
+  })
+
+  it('does not render transaction drawer by default', () => {
+    const wrapper = factory()
+    const item = wrapper.find("[data-test='transaction-drawer']")
+
+    expect(item.exists()).toBeFalsy()
+  })
+
+  context('when new transaction button is clicked', () => {
+    it('renders transaction drawer with origin account', async () => {
+      const wrapper = factory()
+      await wrapper.find("[data-test='new-transaction']").vm.$emit('click')
+
+      const drawer = wrapper.find("[data-test='transaction-drawer']")
+
+      expect(drawer.props().originAccount).toEqual(account)
+    })
+  })
+})

--- a/tests/unit/specs/components/sad/SadAlert.spec.js
+++ b/tests/unit/specs/components/sad/SadAlert.spec.js
@@ -8,7 +8,7 @@ const VARIANTS = ['error', 'success', 'warning']
 const factory = (args = {}) => factoryBuilder(SadAlert, {
   propsData: {
     duration: 0,
-    id: faker.random.uuid(),
+    id: faker.datatype.uuid(),
     message: faker.lorem.sentence(),
     variant: sample(VARIANTS),
     ...args,
@@ -70,7 +70,7 @@ describe('SadAlert', () => {
 
   describe('when close button is clicked', () => {
     it('emits close', async () => {
-      const id = faker.random.uuid()
+      const id = faker.datatype.uuid()
       const wrapper = factory({ id })
 
       await wrapper.find("[data-test='close-icon']").trigger('click')
@@ -84,7 +84,7 @@ describe('SadAlert', () => {
       jest.useFakeTimers()
 
       const duration = 5000
-      const id = faker.random.uuid()
+      const id = faker.datatype.uuid()
       const wrapper = factory({ duration, id })
 
       jest.advanceTimersByTime(duration)

--- a/tests/unit/specs/components/sad/SadCheckbox.spec.js
+++ b/tests/unit/specs/components/sad/SadCheckbox.spec.js
@@ -1,0 +1,57 @@
+import SadCheckbox from '@/components/sad/SadCheckbox'
+import sample from 'lodash/sample'
+import { factoryBuilder } from '#/factory-builder'
+
+const factory = (args = {}) => factoryBuilder(SadCheckbox, {
+  propsData: {
+    label: 'label',
+    name: 'name',
+    value: '',
+    ...args,
+  },
+})
+
+describe('SadCheckbox', () => {
+  it('renders label', () => {
+    const wrapper = factory()
+    const item = wrapper.find("[data-test='label']")
+
+    expect(item.text()).toEqual('label')
+  })
+
+  it('matches checkbox checked prop with value', () => {
+    const value = sample([true, false])
+    const wrapper = factory({ value })
+    const item = wrapper.find("[data-test='input']")
+
+    expect(item.element.checked).toEqual(value)
+  })
+
+  describe('when tip prop is given', () => {
+    it('renders tip with tip', () => {
+      const wrapper = factory({ tip: 'Help text' })
+
+      const tip = wrapper.find("[data-test='tip']")
+
+      expect(tip.props()).toMatchObject({
+        text: 'Help text',
+        variant: 'info',
+      })
+    })
+  })
+
+  describe('when input element emits input', () => {
+    it('emits input with input checked state', async () => {
+      const checked = sample([true, false])
+      const wrapper = factory()
+
+      const input = wrapper.find("[data-test='input']")
+      input.element.checked = checked
+      await input.trigger('input')
+
+      expect(wrapper.emitted().input).toEqual([
+        [checked],
+      ])
+    })
+  })
+})

--- a/tests/unit/specs/components/sad/SadDatepicker.spec.js
+++ b/tests/unit/specs/components/sad/SadDatepicker.spec.js
@@ -1,0 +1,79 @@
+import SadDatePicker from '@/components/sad/SadDatePicker'
+import { factoryBuilder } from '#/factory-builder'
+
+const factory = (args = {}) => factoryBuilder(SadDatePicker, {
+  propsData: {
+    label: 'label',
+    name: 'name',
+    format: 'MM 👍 yyyy 👎 dd',
+    value: '',
+    ...args,
+  },
+})
+
+describe('SadDatePicker', () => {
+  it('renders label', () => {
+    const wrapper = factory()
+    const item = wrapper.find("[data-test='label']")
+
+    expect(item.props().text).toEqual('label')
+  })
+
+  it('always emits dates using yyyy-MM-dd format', () => {
+    const wrapper = factory()
+    const item = wrapper.find("[data-test='picker']")
+
+    expect(item.props().valueFormat).toEqual('yyyy-MM-dd')
+  })
+
+  it('renders date picker with proper date format', () => {
+    const wrapper = factory()
+    const item = wrapper.find("[data-test='picker']")
+
+    expect(item.props().format).toEqual('MM 👍 yyyy 👎 dd')
+  })
+
+  describe('when error prop is given', () => {
+    it('renders tip with info', () => {
+      const wrapper = factory({ tip: 'Help text' })
+
+      const tip = wrapper.find("[data-test='tip']")
+
+      expect(tip.props()).toMatchObject({
+        text: 'Help text',
+        variant: 'info',
+      })
+    })
+  })
+
+  describe('when error prop is given', () => {
+    it('renders tip with error', () => {
+      const wrapper = factory({ error: 'Invalid' })
+
+      const tip = wrapper.find("[data-test='tip']")
+
+      expect(tip.props()).toMatchObject({
+        text: 'Invalid',
+        variant: 'error',
+      })
+    })
+  })
+
+  it('proxies blur events from picker', async () => {
+    const wrapper = factory()
+
+    await wrapper.find("[data-test='picker']").vm.$emit('blur')
+
+    expect(wrapper.emitted().blur).toBeTruthy()
+  })
+
+  it('proxies input events from picker', async () => {
+    const wrapper = factory()
+
+    await wrapper
+      .find("[data-test='picker']")
+      .vm.$emit('input', '2021-03-05')
+
+    expect(wrapper.emitted().input).toBeTruthy()
+  })
+})

--- a/tests/unit/specs/components/sad/SadInput.spec.js
+++ b/tests/unit/specs/components/sad/SadInput.spec.js
@@ -50,7 +50,7 @@ describe('SadInput', () => {
 
       const input = wrapper.find("[data-test='input']")
 
-      expect(input.classes()).toContain('sad-input--error')
+      expect(input.classes()).toContain('error')
     })
   })
 

--- a/tests/unit/specs/components/sad/SadSelect.spec.js
+++ b/tests/unit/specs/components/sad/SadSelect.spec.js
@@ -1,24 +1,53 @@
 import SadSelect from '@/components/sad/SadSelect'
 import { factoryBuilder } from '#/factory-builder'
 
+const groupOptions = [
+  {
+    label: 'label 1',
+    options: [{ value: 'v1', label: 'value 1' }],
+  },
+  {
+    label: 'label 2',
+    options: [
+      { value: 'v2', label: 'value 2' },
+      { value: 'v3', label: 'value 3' },
+    ],
+  },
+]
+const singleOptions = [
+  { value: 'v1', label: 'value 1' },
+  { value: 'v2', label: 'value 2' },
+]
+
 const factory = (args = {}) => factoryBuilder(SadSelect, {
   propsData: {
     label: 'label',
     name: 'name',
     value: '',
-    options: [
-      { label: 'label 1', options: [{ value: 'v1', label: 'value 1' }] },
-      { label: 'label 2', options: [{ value: 'v2', label: 'value 2' }] },
-    ],
+    options: singleOptions,
     ...args,
   },
 })
 
 describe('SadSelect', () => {
-  it('has no placeholder', () => {
+  it('has no placeholder by default', () => {
     const wrapper = factory()
 
     expect(wrapper.vm.placeholder).toEqual('')
+  })
+
+  it('is filterable', () => {
+    const wrapper = factory()
+    const item = wrapper.find("[data-test='select']")
+
+    expect(item.props().filterable).toEqual(true)
+  })
+
+  it('does not allow creating by default', () => {
+    const wrapper = factory()
+    const item = wrapper.find("[data-test='select']")
+
+    expect(item.props().allowCreate).toEqual(false)
   })
 
   it('renders label', () => {
@@ -36,7 +65,7 @@ describe('SadSelect', () => {
     })
   })
 
-  context('when error prop is given', () => {
+  describe('when error prop is given', () => {
     it('renders tip with error', () => {
       const wrapper = factory({ error: 'Invalid' })
 
@@ -46,6 +75,29 @@ describe('SadSelect', () => {
         text: 'Invalid',
         variant: 'error',
       })
+    })
+  })
+
+  describe('when select emits blur', () => {
+    it('emits blur', async () => {
+      const wrapper = factory()
+
+      await wrapper.find("[data-test='select']").vm.$emit('blur')
+
+      expect(wrapper.emitted().blur).toBeTruthy()
+    })
+  })
+
+  describe('when is grouped', () => {
+    it('renders options grouped', () => {
+      const wrapper = factory({ grouped: true, options: groupOptions })
+
+      const groups = wrapper.findAll("[data-test='select-group']")
+      const groupOneOpts = groups.at(0).findAll("[data-test='select-option']")
+      const groupTwoOpts = groups.at(1).findAll("[data-test='select-option']")
+
+      expect(groupOneOpts.length).toEqual(1)
+      expect(groupTwoOpts.length).toEqual(2)
     })
   })
 })

--- a/tests/unit/specs/components/transactions/TransactionDetails.spec.js
+++ b/tests/unit/specs/components/transactions/TransactionDetails.spec.js
@@ -1,0 +1,84 @@
+import factories from '#/factories'
+import TransactionDetails from '@/components/transactions/TransactionDetails'
+import { factoryBuilder } from '#/factory-builder'
+import { currencySettings } from '@/support/money'
+import * as categoriesRepo from '@/repositories/categories'
+import * as categoryGroupsRepo from '@/repositories/category-groups'
+import * as budgetsRepo from '@/repositories/budgets'
+import * as payeesRepo from '@/repositories/payees'
+
+const account = factories.account.budget().build()
+const budget = factories.budget.build()
+const payees = factories.payee.buildList(2)
+const categoryGroups = factories.categoryGroup.buildList(2)
+const categories = [
+  factories.category.build({ categoryGroupId: categoryGroups[0].id }),
+  factories.category.build({ categoryGroupId: categoryGroups[0].id }),
+  factories.category.build({ categoryGroupId: categoryGroups[1].id }),
+]
+
+const factory = (args = {}) => {
+  budgetsRepo.openBudget.value = budget
+  categoriesRepo.categories.value = categories
+  categoryGroupsRepo.categoryGroups.value = categoryGroups
+  payeesRepo.payees.value = payees
+
+  return factoryBuilder(TransactionDetails, {
+    propsData: {
+      originAccount: args.account || account,
+    },
+  })
+}
+
+describe('TransactionDetails', () => {
+  it('renders payee select', () => {
+    const wrapper = factory()
+    const item = wrapper.find("[data-test='payee']")
+
+    expect(item.props()).toMatchObject({
+      options: payees.map(p => ({ label: p.name, value: p.name })),
+      allowCreate: true,
+      label: expect.stringMatching(/payee/),
+    })
+  })
+
+  it('renders reference-at datepicker', () => {
+    const wrapper = factory()
+    const item = wrapper.find("[data-test='reference-at']")
+
+    expect(item.props()).toMatchObject({
+      format: budget.dateFormat,
+      label: expect.stringMatching(/referenceAt/),
+    })
+  })
+
+  it('renders amount input', () => {
+    const wrapper = factory()
+    const item = wrapper.find("[data-test='amount']")
+
+    expect(item.props()).toMatchObject({
+      money: currencySettings(budget),
+      label: expect.stringMatching(/amount/),
+    })
+  })
+
+  it('renders memo input', () => {
+    const wrapper = factory()
+    const item = wrapper.find("[data-test='memo']")
+
+    expect(item.props()).toMatchObject({
+      label: expect.stringMatching(/memo/),
+      tip: expect.stringMatching(/memoTip/),
+    })
+  })
+
+  it('renders cleared-at checkbox', () => {
+    const wrapper = factory()
+    const item = wrapper.find("[data-test='cleared-at']")
+
+    expect(item.props()).toMatchObject({
+      label: expect.stringMatching(/clearedAt/),
+      tip: expect.stringMatching(/clearedAtTip/),
+    })
+  })
+})

--- a/tests/unit/specs/repositories/budgets.spec.js
+++ b/tests/unit/specs/repositories/budgets.spec.js
@@ -10,7 +10,7 @@ describe('BudgetsRepository', () => {
 
   describe('#getBudgetById', () => {
     it('dispatches a GET to api', async () => {
-      const id = faker.random.uuid
+      const id = faker.datatype.uuid
 
       await repository.getBudgetById(id)
 
@@ -18,7 +18,7 @@ describe('BudgetsRepository', () => {
     })
 
     it('updates monthly budgets with newly-created resource', async () => {
-      const id = faker.random.uuid
+      const id = faker.datatype.uuid
       const budget = factories.budget.build()
 
       api.get.mockResolvedValueOnce(budget)

--- a/tests/unit/specs/repositories/categories.spec.js
+++ b/tests/unit/specs/repositories/categories.spec.js
@@ -37,6 +37,29 @@ describe('CategoriesRepository', () => {
     })
   })
 
+  describe('#categoriesGroupedByGroupId', () => {
+    it('groups categories according to their group id', () => {
+      const categoryGroups = factories.categoryGroup.buildList(2)
+      const categories = [
+        factories.category.build({ categoryGroupId: categoryGroups[0].id }),
+        factories.category.build({ categoryGroupId: categoryGroups[1].id }),
+        factories.category.build({ categoryGroupId: categoryGroups[0].id }),
+      ]
+
+      repository.categories.value = categories
+
+      expect(repository.categoriesGroupedByGroupId.value).toEqual({
+        [categoryGroups[0].id]: [
+          categories[0],
+          categories[2],
+        ],
+        [categoryGroups[1].id]: [
+          categories[1],
+        ],
+      })
+    })
+  })
+
   describe('#createCategory', () => {
     it('dispatches a POST to api', async () => {
       const budgetId = faker.datatype.uuid()

--- a/tests/unit/specs/repositories/categories.spec.js
+++ b/tests/unit/specs/repositories/categories.spec.js
@@ -39,7 +39,7 @@ describe('CategoriesRepository', () => {
 
   describe('#createCategory', () => {
     it('dispatches a POST to api', async () => {
-      const budgetId = faker.random.uuid()
+      const budgetId = faker.datatype.uuid()
       const params = { mock: true, budgetId }
 
       await repository.createCategory(params)
@@ -63,7 +63,7 @@ describe('CategoriesRepository', () => {
 
   describe('#getCategories', () => {
     it('dispatches a GET to api', async () => {
-      const budgetId = faker.random.uuid()
+      const budgetId = faker.datatype.uuid()
       const params = { mock: true, budgetId }
 
       await repository.getCategories(params)

--- a/tests/unit/specs/repositories/category-groups.spec.js
+++ b/tests/unit/specs/repositories/category-groups.spec.js
@@ -21,7 +21,7 @@ describe('CategoryGroupRepository', () => {
 
   describe('#createCategoryGroup', () => {
     it('dispatches a POST to api', async () => {
-      const budgetId = faker.random.uuid()
+      const budgetId = faker.datatype.uuid()
       const params = { mock: true, budgetId }
 
       await repository.createCategoryGroup(params)
@@ -45,7 +45,7 @@ describe('CategoryGroupRepository', () => {
 
   describe('#getCategoryGroups', () => {
     it('dispatches a GET to api', async () => {
-      const budgetId = faker.random.uuid()
+      const budgetId = faker.datatype.uuid()
       const params = { mock: true, budgetId }
 
       await repository.getCategoryGroups(params)

--- a/tests/unit/specs/repositories/monthly-budgets.spec.js
+++ b/tests/unit/specs/repositories/monthly-budgets.spec.js
@@ -10,7 +10,7 @@ describe('MonthlyBudgetsRepository', () => {
 
   describe('#createMonthlyBudget', () => {
     it('dispatches a POST to api', async () => {
-      const budgetId = faker.random.uuid()
+      const budgetId = faker.datatype.uuid()
       const params = { mock: true, budgetId }
 
       await repository.createMonthlyBudget(params)
@@ -34,8 +34,8 @@ describe('MonthlyBudgetsRepository', () => {
 
   describe('#updateMonthlyBudget', () => {
     it('dispatches a PUT to api', async () => {
-      const budgetId = faker.random.uuid()
-      const id = faker.random.uuid()
+      const budgetId = faker.datatype.uuid()
+      const id = faker.datatype.uuid()
       const params = { mock: true, budgetId, id }
 
       await repository.updateMonthlyBudget(params)

--- a/tests/unit/specs/repositories/months.spec.js
+++ b/tests/unit/specs/repositories/months.spec.js
@@ -10,7 +10,7 @@ describe('MonthsRepository', () => {
 
   describe('#getMonthByIso', () => {
     it('dispatches a GET to api', async () => {
-      const id = faker.random.uuid
+      const id = faker.datatype.uuid
       const isoMonth = '2020-03'
       const params = { budgetId: id, isoMonth }
 
@@ -22,7 +22,7 @@ describe('MonthsRepository', () => {
     })
 
     it('updates monthly budgets with newly-created resource', async () => {
-      const id = faker.random.uuid
+      const id = faker.datatype.uuid
       const isoMonth = '2020-03'
       const params = { budgetId: id, isoMonth }
       const month = factories.month.build()

--- a/tests/unit/specs/repositories/payees.spec.js
+++ b/tests/unit/specs/repositories/payees.spec.js
@@ -1,0 +1,34 @@
+import * as api from '@/api'
+import * as repository from '@/repositories/payees'
+import factories from '#/factories'
+import faker from 'faker'
+
+describe('PayeesRepository', () => {
+  beforeEach(() => {
+    repository.payees.value = []
+  })
+
+  describe('#getPayees', () => {
+    it('dispatches a GET to api', async () => {
+      const budgetId = faker.datatype.uuid()
+      const params = { mock: true, budgetId }
+
+      await repository.getPayees(params)
+
+      expect(api.get).toHaveBeenCalledWith(
+        `budgets/${budgetId}/payees`,
+      )
+    })
+
+    it('saves fetched resources to local payees', async () => {
+      const params = { mock: true }
+      const payees = factories.payee.buildList(2)
+
+      api.get.mockResolvedValueOnce(payees)
+
+      await repository.getPayees(params)
+
+      expect(repository.payees.value).toEqual(payees)
+    })
+  })
+})

--- a/tests/unit/specs/use/tip.spec.js
+++ b/tests/unit/specs/use/tip.spec.js
@@ -14,6 +14,24 @@ const factory = (args = {}) => factoryBuilder(DummyComponent, {
 })
 
 describe('useTip', () => {
+  describe('#errorClass', () => {
+    describe('when error prop is set', () => {
+      it('returns `error`', () => {
+        const { vm } = factory({ error: true })
+
+        expect(vm.errorClass).toEqual('error')
+      })
+    })
+
+    describe('when error prop is falsy', () => {
+      it('returns empty string', () => {
+        const { vm } = factory({ error: false })
+
+        expect(vm.errorClass).toEqual('')
+      })
+    })
+  })
+
   describe('#tipText', () => {
     describe('when error prop is present', () => {
       it('is error prop', () => {

--- a/tests/unit/specs/views/dashboard/AccountShow.spec.js
+++ b/tests/unit/specs/views/dashboard/AccountShow.spec.js
@@ -38,6 +38,15 @@ describe('AccountShow', () => {
     })
   })
 
+  it('renders AccountToolbar using selected account', async () => {
+    const wrapper = factory()
+
+    await flushPromises()
+    const item = wrapper.find("[data-test='toolbar']")
+
+    expect(item.props()).toEqual({ account: selectedAccount })
+  })
+
   context('while fetching account', () => {
     it('renders Loading component', async () => {
       const wrapper = factory()


### PR DESCRIPTION
📓 **CHANGELOG**
- Design the `TransactionDetails` component
- Implement an `AccountToolbar` component
- Add `payees` repository
- Implement two new UI components – including `error` state:
  - `SadDatePicker`
  - `SadCheckbox`
- Enhance `SadSelect` to:
  - Allow both grouped and ungrouped options
  - Show a red border when `error` prop is present

🖼️ **SCREENSHOTS**
<img width="885" alt="Screen Shot 2021-04-11 at 19 31 52" src="https://user-images.githubusercontent.com/28878074/114323686-b12ec300-9afc-11eb-81be-7ce40f976da4.png">
