### PR TITLE
Fix AccountShow

### DIFF
--- a/src/components/sad/SadSwitch.vue
+++ b/src/components/sad/SadSwitch.vue
@@ -30,16 +30,24 @@ export default defineComponent({
 
 <style lang="scss">
 .el-switch__core {
-  background: var(--color-info);
-  border-color: var(--color-info);
+  background: var(--color-success);
+  border-color: var(--color-success);
 }
 
-.el-switch__label.is-active {
-  color: var(--color-primary);
+.el-switch__label {
+  color: var(--text-default);
+}
+
+.el-switch__label--right.is-active {
+  color: var(--color-error);
+}
+
+.el-switch__label--left.is-active {
+  color: var(--color-success);
 }
 
 .el-switch.is-checked .el-switch__core {
-  background: var(--color-primary);
-  border-color: var(--color-primary);
+  background: var(--color-error);
+  border-color: var(--color-error);
 }
 </style>

--- a/src/lang/pt-BR.json
+++ b/src/lang/pt-BR.json
@@ -21,7 +21,8 @@
   },
   "errors": {
     "accounts": {
-      "duplicate": "Você já cadastrou essa conta."
+      "duplicate": "Você já cadastrou essa conta.",
+      "not-found": "Parece que essa conta não existe..."
     },
     "generic": "Algo deu errado. Tente novamente.",
     "monthly-budgets": {

--- a/src/views/dashboard/AccountShow.vue
+++ b/src/views/dashboard/AccountShow.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="account-show">
     <loading
-      v-if="isLoading"
+      v-if="isEmpty(account)"
       class="account-show__loading"
       data-test="loading"
     />
@@ -23,10 +23,13 @@
 
 <script>
 import { openBudget } from '@/repositories/budgets'
-import { accounts, getAccountById } from '@/repositories/accounts'
+import { getAccountById } from '@/repositories/accounts'
+import { useI18n } from '@/use/i18n'
+import alert from '@/support/alert'
 import AccountHeader from '@/components/accounts/AccountHeader'
 import AccountToolbar from '@/components/accounts/AccountToolbar'
 import Loading from '@/components/Loading'
+import isEmpty from 'lodash/isEmpty'
 
 export default {
   name: 'AccountShow',
@@ -38,33 +41,21 @@ export default {
   },
 
   setup () {
-    return { openBudget }
+    const { t } = useI18n()
+
+    return { isEmpty, openBudget, t }
   },
 
-  data () {
-    return {
-      account: {},
-      isLoading: true,
+  mounted () {
+    if (isEmpty(this.account)) {
+      alert.error(this.t('errors.accounts.not-found'))
+      this.$router.push({ name: 'AllAccounts' })
     }
   },
 
-  async mounted () {
-    await this.fetchAccount()
-  },
-
-  methods: {
-    fetchAccount () {
-      if (!accounts.value.length) return
-
-      this.isLoading = true
-      this.account = getAccountById(this.$route.params.id)
-      this.isLoading = false
-    },
-  },
-
-  watch: {
-    '$route.params.id' () {
-      this.fetchAccount()
+  computed: {
+    account () {
+      return getAccountById(this.$route.params.id) || {}
     },
   },
 }


### PR DESCRIPTION
**CHANGELOG**
- FIx `SadSwitch` colors to be red/green
- Add a redirect to `AllAccounts` in case of trying to access a non-existant account

**SCREENSHOTS**
<img width="391" alt="Screen Shot 2021-05-04 at 10 52 54" src="https://user-images.githubusercontent.com/28878074/117015549-39e9ea80-acc8-11eb-846a-6f05007a4091.png">

<hr />

<img width="387" alt="Screen Shot 2021-05-04 at 10 53 00" src="https://user-images.githubusercontent.com/28878074/117015556-3bb3ae00-acc8-11eb-9137-80c3f5c69500.png">
