### PR TITLE
Place currency symbol as prefix of money inputs

### DIFF
--- a/src/components/accounts/CreateAccountModal.vue
+++ b/src/components/accounts/CreateAccountModal.vue
@@ -30,6 +30,7 @@
         v-model="form.currentBalance"
         class="create-account__item"
         name="currentBalance"
+        :prefix="currencySymbol"
         :label="st('currentBalance')"
         :tip="st('currentBalanceTip')"
         data-test="current-balance"
@@ -59,6 +60,7 @@ import { currencyToCents } from '@/support/money';
 import { handleApiError } from '@/api/errors';
 import { SetupContext, reactive, defineComponent, PropType } from 'vue';
 import { AccountType, Budget } from '@/types/models';
+import { symbolOf } from '@/support/currencies';
 
 export default defineComponent({
   name: 'CreateAccountModal',
@@ -98,6 +100,7 @@ export default defineComponent({
       label: t(`account.type.${type}`),
       value: type,
     }));
+    const currencySymbol = symbolOf(props.budget.currency);
 
     const handleSubmit = async () => {
       try {
@@ -112,7 +115,7 @@ export default defineComponent({
       }
     };
 
-    return { accountTypes, form, handleSubmit, st, t };
+    return { accountTypes, currencySymbol, form, handleSubmit, st, t };
   },
 });
 </script>

--- a/src/components/monthly-budgets/MonthlyBudgetDetails.vue
+++ b/src/components/monthly-budgets/MonthlyBudgetDetails.vue
@@ -21,6 +21,7 @@
       v-model="form.budgeted"
       class="mb-details__control"
       :label="st('budgeted')"
+      :prefix="currencySymbol"
       name="budgeted"
       data-test="budgeted"
     />
@@ -63,6 +64,7 @@ import {
   PropType,
 } from 'vue';
 import { MonthlyBudget } from '@/types/models';
+import { symbolOf } from '@/support/currencies';
 
 export default defineComponent({
   name: 'MonthlyBudgetDetails',
@@ -91,6 +93,7 @@ export default defineComponent({
     const { st, t } = useI18n('MonthlyBudgetDetails');
 
     const isEdit = computed(() => Boolean(props.monthlyBudget.id));
+    const currencySymbol = computed(() => symbolOf(openBudget.value.currency));
 
     const moneySettings = currencySettings(openBudget.value);
 
@@ -130,6 +133,7 @@ export default defineComponent({
     return {
       categoriesGrouped,
       currentMonth,
+      currencySymbol,
       form,
       isEdit,
       handleSubmit,

--- a/src/components/sad/SadInput.vue
+++ b/src/components/sad/SadInput.vue
@@ -1,17 +1,22 @@
 <template>
-  <div>
+  <div class="sad-input">
     <sad-label to="name" :text="label" data-test="label" />
-    <input
-      :id="name"
-      v-bind="$attrs"
-      :value="modelValue"
-      class="sad-input"
-      :class="[errorClass]"
-      data-test="input"
-      :placeholder="placeholder"
-      :type="type"
-      @input="(e) => $emit('update:model-value', e.target.value)"
-    />
+    <div class="sad-input__wrapper">
+      <div v-if="prefix" class="sad-input__prefix" data-test="prefix">
+        {{ prefix }}
+      </div>
+      <input
+        :id="name"
+        v-bind="$attrs"
+        :value="modelValue"
+        class="sad-input__control"
+        :class="[errorClass]"
+        data-test="input"
+        :placeholder="placeholder"
+        :type="type"
+        @input="(e) => $emit('update:model-value', e.target.value)"
+      />
+    </div>
     <sad-tip
       v-if="tipText"
       class="sad-input__tip"
@@ -30,11 +35,11 @@ import { defineComponent } from 'vue';
 
 export default defineComponent({
   props: {
-    label: {
+    error: {
       type: String,
       default: '',
     },
-    error: {
+    label: {
       type: String,
       default: '',
     },
@@ -47,6 +52,10 @@ export default defineComponent({
       required: true,
     },
     placeholder: {
+      type: String,
+      default: '',
+    },
+    prefix: {
       type: String,
       default: '',
     },
@@ -77,19 +86,32 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .sad-input {
-  border: 1px solid var(--input-border);
-  border-radius: $radius-4;
-  color: var(--text-default);
-  height: $base * 10;
-  padding: $base * 2;
-  width: 100%;
+  &__prefix {
+    color: var(--color-info);
+    margin-right: $base * 2;
+    margin-top: $base/2;
+  }
 
-  @extend %body-1;
+  &__wrapper {
+    align-items: center;
+    border: 1px solid var(--input-border);
+    border-radius: $radius-4;
+    color: var(--text-default);
+    display: flex;
+    height: $base * 10;
+    padding: $base * 2;
+    width: 100%;
 
-  &:focus,
-  &:active {
-    border-color: var(--input-focus);
-    transition: 0.2s;
+    &:focus-within {
+      border-color: var(--input-focus);
+      transition: 0.2s;
+    }
+  }
+
+  &__control {
+    flex-grow: 1;
+
+    @extend %body-1;
   }
 
   &__tip {

--- a/src/components/transactions/TransactionDetails.vue
+++ b/src/components/transactions/TransactionDetails.vue
@@ -45,7 +45,7 @@
       v-model="form.amount"
       class="transaction-details__control"
       :label="st('amount')"
-      :money="money"
+      :prefix="currencySymbol"
       name="amount"
       data-test="amount"
     />
@@ -104,6 +104,7 @@ import {
   reactive,
 } from 'vue';
 import { Account, NullishDate } from '@/types/models';
+import { symbolOf } from '@/support/currencies';
 
 export default defineComponent({
   name: 'TransactionDetails',
@@ -136,6 +137,7 @@ export default defineComponent({
     const { categoryOptions } = useBudgetCategories();
 
     const money = currencySettings(openBudget.value);
+    const currencySymbol = computed(() => symbolOf(openBudget.value.currency));
 
     const payeeOptions = computed(() =>
       payees.value.map((p) => ({
@@ -175,6 +177,7 @@ export default defineComponent({
 
     return {
       categoryOptions,
+      currencySymbol,
       form,
       handleClearedAt,
       handleSubmit,

--- a/src/support/currencies.ts
+++ b/src/support/currencies.ts
@@ -180,3 +180,6 @@ export default currencies;
  * All supported currencies as their ISO 4217 codes
  */
 export type Currency = keyof typeof currencies;
+
+export const symbolOf = (isoCurrency: Currency): string =>
+  currencies[isoCurrency];

--- a/tests/unit/specs/components/sad/SadInput.spec.js
+++ b/tests/unit/specs/components/sad/SadInput.spec.js
@@ -32,6 +32,13 @@ describe('SadInput', () => {
         'label',
       );
     });
+
+    it('does not render prefix', () => {
+      const wrapper = factory();
+      const item = wrapper.find("[data-test='prefix']");
+
+      expect(item.exists()).toBeFalsy();
+    });
   });
 
   describe('when error prop is given', () => {
@@ -62,6 +69,15 @@ describe('SadInput', () => {
       await wrapper.find("[data-test='input']").trigger('input');
 
       expect(wrapper.emitted()['update:model-value']).toBeTruthy();
+    });
+  });
+
+  describe('when prefix is given', () => {
+    it('renders prefix', () => {
+      const wrapper = factory({ props: { prefix: '🐛' } });
+      const item = wrapper.find("[data-test='prefix']");
+
+      expect(item.text()).toEqual('🐛');
     });
   });
 });

--- a/tests/unit/specs/support/currencies.spec.ts
+++ b/tests/unit/specs/support/currencies.spec.ts
@@ -1,4 +1,5 @@
-import currencies from '@/support/currencies';
+import { sample } from '@/support/collection';
+import currencies, { Currency, symbolOf } from '@/support/currencies';
 
 describe('currencies', () => {
   it('maps every ISO abbrev to its corresponding symbol', () => {
@@ -177,5 +178,13 @@ describe('currencies', () => {
       ZAR: 'R',
       ZWD: 'Z$',
     });
+  });
+});
+
+describe('symbolOf', () => {
+  it('returns the symbol of a given ISO currency', () => {
+    const isoCurrency: Currency = sample(Object.keys(currencies)) as Currency;
+
+    expect(symbolOf(isoCurrency)).toEqual(currencies[isoCurrency]);
   });
 });


### PR DESCRIPTION
🌟 **NEW**
- Allow placing prefixes on `SadInput`
- Include budget's currency symbol as prefix for money inputs 

🖼 **SCREENSHOTS**
<img width="390" alt="Screen Shot 2021-06-27 at 11 50 43" src="https://user-images.githubusercontent.com/28878074/123549581-1d09ea80-d740-11eb-8d39-641cdb963995.png">

<hr />

<img width="388" alt="Screen Shot 2021-06-27 at 11 49 55" src="https://user-images.githubusercontent.com/28878074/123549586-1f6c4480-d740-11eb-9bdb-92d8c482b09e.png">

<hr />

<img width="587" alt="Screen Shot 2021-06-27 at 11 50 17" src="https://user-images.githubusercontent.com/28878074/123549582-1ed3ae00-d740-11eb-8fbf-1fd5498449a9.png">


